### PR TITLE
Encode/decode rules

### DIFF
--- a/backup/moodle2/backup_dialogue_activity_task.class.php
+++ b/backup/moodle2/backup_dialogue_activity_task.class.php
@@ -52,6 +52,18 @@ class backup_dialogue_activity_task extends backup_activity_task {
      * @return string
      */
     static public function encode_content_links($content) {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot,"/");
+
+        // Link to the list of dialogues
+        $search="/(".$base."\/mod\/dialogue\/index.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@DIALOGUEINDEX*$2@$', $content);
+
+        // Link to dialogue view by moduleid
+        $search="/(".$base."\/mod\/dialogue\/view.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@DIALOGUEVIEWBYID*$2@$', $content);
+
         return $content;
     }
 }

--- a/backup/moodle2/restore_dialogue_activity_task.class.php
+++ b/backup/moodle2/restore_dialogue_activity_task.class.php
@@ -62,6 +62,11 @@ class restore_dialogue_activity_task extends restore_activity_task {
      */
     static public function define_decode_rules() {
         $rules = array();
+
+        $rules[] = new restore_decode_rule('DIALOGUEINDEX', '/mod/dialogue/index.php?id=$1', 'course');
+        // Dialogue by cm->id and Dialogue->id
+        $rules[] = new restore_decode_rule('DIALOGUEVIEWBYID', '/mod/dialogue/view.php?id=$1', 'course_module');
+
         return $rules;
 
     } 


### PR DESCRIPTION
These rules allow url rewriting when backing up and restoring courses/activities.
(Last pull request I had the global $CFG missing somehow).

This encodes the urls pointing at dialogue modules, from labels for example, so that when restored elsewhere, they point at the new copy of the module.
