### PR TITLE
Missing addinstance string

### DIFF
--- a/lang/en/dialogue.php
+++ b/lang/en/dialogue.php
@@ -115,6 +115,7 @@ $string['edittime'] = 'Edit time (minutes)';
 $string['edittime_help'] = 'Edit time help';
 $string['otherdialogues'] = 'Other dialogues';
 $string['replyupdated'] = 'Reply updated';
+$string['dialogue:addinstance'] = 'Add a new dialogue';
 $string['dialogue:open'] = 'Open';
 $string['dialogue:participate'] = 'Participate';
 $string['dialogue:manage'] = 'Manage';


### PR DESCRIPTION
The role editing page needs this string for displaying the cap in its list.
