### PR TITLE
Found an issue with Moodle 1.9 upgrade code

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -95,7 +95,7 @@ function xmldb_dialogue_upgrade($oldversion=0) {
                             }
                         }
                     }
-                    $DB->set_field('dialogue_entries', 'text', $content, array('id'=> $entry->id));
+                    $DB->set_field('dialogue_entries', 'text', $text, array('id'=> $entry->id));
                 }
 
                 


### PR DESCRIPTION
Hi Troy,

Found when I was upgrade a Moodle 1.9 site with extensive use of Dialogue that it would fail on updating the database with plugin files in the dialogue.

Notice: Undefined variable: content in /var/htdocs/moodle/mod/dialogue/db/upgrade.php on line 84
!!! Error writing to database !!!
!! ERROR:  null value in column "text" violates not-null constraint
UPDATE mdl_dialogue_entries SET text = NULL WHERE id = $1
[array (
  0 =&gt; '7382',
)] !!
