### PR TITLE
user_picture::fields() is deprecated in Moodle 3.11

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -200,7 +200,10 @@ function dialogue_process_bulk_openrules() {
 
                 $withcapability = 'mod/dialogue:receive';
                 $groupid = 0; // It either a course or a group, default to course.
-                $requiredfields = user_picture::fields('u');
+                $requiredfields = \core_user\fields::for_userpic()
+                    ->get_sql('u', false, '', '', false)
+                    ->selects;
+
                 if ($record->type == 'group') {
                     $groupid = $record->sourceid;
                 }

--- a/locallib.php
+++ b/locallib.php
@@ -40,7 +40,9 @@ function dialogue_search_potentials(\mod_dialogue\dialogue $dialogue, $query = '
     $wheres = array();
     $wheresql  = '';
 
-    $userfields = user_picture::fields('u');
+    $userfields = \core_user\fields::for_userpic()
+        ->get_sql('u', false, '', '', false)
+        ->selects;
 
     $cm                 = $dialogue->cm;
     $context            = $dialogue->context;
@@ -157,7 +159,9 @@ function dialogue_get_user_details(\mod_dialogue\dialogue $dialogue, $userid) {
     static $cache;
 
     $context        = $dialogue->context;
-    $requiredfields = user_picture::fields('u');
+    $requiredfields = \core_user\fields::for_userpic()
+        ->get_sql('u', false, '', '', false)
+        ->selects;
 
     if (!isset($cache)) {
         $cache = cache::make('mod_dialogue', 'userdetails');


### PR DESCRIPTION
Fixes "user_picture::fields() is deprecated" warning in Moodle 3.11