### PR TITLE
Fix #117 fa icons not displaying on Moodle 4.x

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1359,7 +1359,6 @@ body.path-mod-dialogue #region-main .fa {
     font-family: FontAwesome;
     -webkit-font-smoothing: antialiased;
     font-style: normal;
-    font-weight: normal;
     line-height: 1;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Removing this line solved the problem.