### PR TITLE
Remove view participants capability while creating dialogue

### DIFF
--- a/classes/external/search_users.php
+++ b/classes/external/search_users.php
@@ -100,7 +100,7 @@ class search_users extends external_api {
             $exceptionparam->courseid = $params['courseid'];
             throw new moodle_exception('errorcoursecontextnotvalid' , 'webservice', '', $exceptionparam);
         }
-        course_require_view_participants($context);
+
         if (!has_capability('moodle/site:accessallgroups', $context) &&
             $DB->record_exists('dialogue', ['id' => $cm->instance, 'usecoursegroups' => 1])) {
 


### PR DESCRIPTION
Hi,
This removes the 'viewparticipants' capability check from the webservice that is called in the dialogue creation page. 
As student is a role with the least privilege, it makes sense to remove it entirely rather than checking the role and removing this capability check.
This change is needed for data protection reasons.
Regards,
Sumaiya