### PR TITLE
Display user fullname and replace capability check in dialogue creation

### DIFF
--- a/classes/external/search_users.php
+++ b/classes/external/search_users.php
@@ -100,7 +100,9 @@ class search_users extends external_api {
             $exceptionparam->courseid = $params['courseid'];
             throw new moodle_exception('errorcoursecontextnotvalid' , 'webservice', '', $exceptionparam);
         }
-        course_require_view_participants($context);
+
+        require_capability('mod/dialogue:open', $context);
+
         if (!has_capability('moodle/site:accessallgroups', $context) &&
             $DB->record_exists('dialogue', ['id' => $cm->instance, 'usecoursegroups' => 1])) {
 

--- a/classes/message.php
+++ b/classes/message.php
@@ -450,16 +450,10 @@ class message implements \renderable {
         $context = $this->dialogue->context;
         $userfrom = $DB->get_record('user', array('id' => $this->_authorid), '*', MUST_EXIST);
         $subject = format_string($this->conversation->subject, true, array('context' => $context));
-
         $a = new \stdClass();
-        $a->userfrom = fullname($userfrom);
         $a->subject = $subject;
         $url = new \moodle_url('/mod/dialogue/view.php', array('id' => $cm->id));
         $a->url = $url->out(false);
-
-        $posthtml = get_string('messageapibasicmessage', 'dialogue', $a);
-        $posttext = html_to_text($posthtml);
-        $smallmessage = get_string('messageapismallmessage', 'dialogue', fullname($userfrom));
 
         $contexturlparams = array('id' => $cm->id, 'conversationid' => $conversationid);
         $contexturl = new \moodle_url('/mod/dialogue/conversation.php', $contexturlparams);
@@ -477,6 +471,14 @@ class message implements \renderable {
             $this->set_flag(dialogue::FLAG_SENT, $participant);
 
             $userto = $DB->get_record('user', array('id' => $participant->id), '*', MUST_EXIST);
+
+            $a->userfrom = dialogue_add_user_fullname($userfrom, $userto, $cm);
+            $a->course = $course->shortname;
+
+            $posthtml = get_string('messageapibasicmessage', 'dialogue', $a);
+            $posttext = html_to_text($posthtml);
+            $smallmessage = get_string('messageapismallmessage', 'dialogue',
+                dialogue_add_user_fullname($userfrom, $userto, $cm));
 
             $eventdata = new \core\message\message();
             $eventdata->courseid = $course->id;

--- a/formlib.php
+++ b/formlib.php
@@ -254,15 +254,14 @@ class mod_dialogue_conversation_form extends mod_dialogue_message_form {
             'ajax' => 'mod_dialogue/form-user-selector',
             'multiple' => true,
             'cmid' => $cm->id,
-            'valuehtmlcallback' => function($value) {
+            'valuehtmlcallback' => function($value, $USER, $cm) {
                 global $OUTPUT;
-
                 $userfieldsapi = \core_user\fields::for_name();
                 $allusernames = $userfieldsapi->get_sql('', false, '', '', false)->selects;
                 $fields = 'id, ' . $allusernames;
                 $user = \core_user::get_user($value, $fields);
                 $useroptiondata = [
-                    'fullname' => fullname($user),
+                    'fullname' => dialogue_add_user_fullname($user, $USER, $cm),
                 ];
                 return $OUTPUT->render_from_template('mod_dialogue/form-user-selector-suggestion', $useroptiondata);
             }

--- a/lang/en/dialogue.php
+++ b/lang/en/dialogue.php
@@ -124,8 +124,8 @@ $string['maxattachmentsize'] = 'Maximum attachment size';
 $string['maxattachmentsize_help'] = 'This setting specifies the largest size of file that can be attached to a dialogue post.';
 $string['message'] = 'Message';
 $string['messageapibasicmessage'] = '
-<p>{$a->userfrom} posted a new message to a conversation you are participating
-in with subject: <i>{$a->subject}</i>
+<p>{$a->userfrom} posted a new message to a conversation you are participating in course: <i>{$a->course}</i>
+with subject: <i>{$a->subject}</i>
 <br/><br/><a href="{$a->url}">View in Moodle</a></p>';
 $string['messageapismallmessage'] = '{$a} posted a new message to a conversation you are participating in';
 $string['messageprovider:post'] = 'Dialogue notifications';

--- a/locallib.php
+++ b/locallib.php
@@ -487,3 +487,19 @@ function dialogue_contains_draft_files($draftid) {
     return (count($draftfiles) > 1) ? true : false;
 }
 
+/**
+ * Get the name for a user - hiding their full name if the required capability
+ * is missing.
+ *
+ * @param stdClass $userviewed the user whose details are being viewed
+ * @param stdClass $userviewedby the user who is viewing these details
+ * @param stdClass $cm  the course module object
+ *
+ * @return string fullname
+ */
+function dialogue_add_user_fullname(stdClass $userviewed, stdClass $userviewedby, stdClass $cm) {
+    $capability = 'moodle/site:viewfullnames';
+    $context = context_module::instance($cm->id);
+    $hasviewfullnames = has_capability($capability, $context, $userviewedby);
+    return fullname($userviewed, $hasviewfullnames);
+}

--- a/renderer.php
+++ b/renderer.php
@@ -71,7 +71,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
         $html .= html_writer::start_div('conversation-body');
 
         $datestrings = (object) dialogue_get_humanfriendly_dates($conversation->timemodified);
-        $datestrings->fullname = fullname($conversation->author);
+        $datestrings->fullname = dialogue_add_user_fullname($conversation->author, $USER, $cm);
         if ($conversation->timemodified >= $today) {
             $openedbyheader = get_string('openedbytoday', 'dialogue', $datestrings);
         } else if ($conversation->timemodified >= $yearago) {
@@ -145,7 +145,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
                     $html .= html_writer::start_tag('tr');
                     $picture = $this->output->user_picture($person, array('class' => 'userpicture img-rounded', 'size' => 20));
                     $html .= html_writer::tag('td', $picture);
-                    $html .= html_writer::tag('td', fullname($person));
+                    $html .= html_writer::tag('td', dialogue_add_user_fullname($person, $USER, $cm));
                     $html .= html_writer::tag('td', $sentonstring . userdate($receivedby->timemodified));
                     $html .= html_writer::end_tag('tr');
                 }
@@ -162,7 +162,8 @@ class mod_dialogue_renderer extends plugin_renderer_base {
             $html .= '&nbsp;' . get_string('participants', 'dialogue');
             foreach ($participants as $participant) {
                 $picture = $this->output->user_picture($participant, array('class' => 'userpicture img-rounded', 'size' => 20));
-                $html .= html_writer::tag('span', $picture . '&nbsp;' . fullname($participant), array('class' => 'participant'));
+                $html .= html_writer::tag('span', $picture . '&nbsp;'
+                . dialogue_add_user_fullname($participant, $USER, $cm), array('class' => 'participant'));
             }
             $html .= html_writer::end_div();
         }
@@ -179,6 +180,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
      * @return string
      */
     public function conversation_listing(\mod_dialogue\conversations $conversations) {
+        global $USER;
         $dialogue = $conversations->dialogue;
         $cm       = $conversations->dialogue->cm;
 
@@ -241,7 +243,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
                     $displayuser = dialogue_get_user_details($dialogue, $record->userid);
                     $avatar = $this->output->user_picture($displayuser, array('class' => 'userpicture img-rounded', 'size' => 48));
                     $html .= html_writer::tag('td', $avatar);
-                    $html .= html_writer::tag('td', fullname($displayuser));
+                    $html .= html_writer::tag('td', dialogue_add_user_fullname($displayuser, $USER, $cm));
                 }
 
                 if (isset($record->subject) && isset($record->body)) {
@@ -257,7 +259,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
                         $participant = dialogue_get_user_details($dialogue, $participantid);
                         $picture = $this->output->user_picture($participant,
                             array('class' => 'userpicture img-rounded', 'size' => 16));
-                        $html .= html_writer::tag('span', $picture.' '.fullname($participant),
+                        $html .= html_writer::tag('span', $picture.' '.dialogue_add_user_fullname($participant, $USER, $cm),
                                                     array('class' => 'participant'));
 
                     }
@@ -306,7 +308,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
      * @return string
      */
     public function render_reply(\mod_dialogue\reply $reply) {
-
+        global $USER;
         $context        = $reply->dialogue->context; // Fetch context from parent dialogue.
         $cm             = $reply->dialogue->cm; // Fetch course module from parent dialogue.
         $conversation   = $reply->conversation; // Fetch parent conversation.
@@ -326,7 +328,7 @@ class mod_dialogue_renderer extends plugin_renderer_base {
         $html .= html_writer::start_div('conversation-body');
 
         $datestrings = (object) dialogue_get_humanfriendly_dates($reply->timemodified);
-        $datestrings->fullname = fullname($reply->author);
+        $datestrings->fullname = dialogue_add_user_fullname($reply->author, $USER, $cm);
         if ($reply->timemodified >= $today) {
             $repliedbyheader = get_string('repliedbytoday', 'dialogue', $datestrings);
         } else if ($reply->timemodified >= $yearago) {


### PR DESCRIPTION
Hi,

This will fix the below issues:

- Remove the requirement for students to have the moodle/course:viewparticipants' capability when creating a dialogue. Instead use the mod/dialogue:open capability check. 
This is a data protection issue for some as it means that this setting hinders the ability to disable Student access to the course participants page. 

- Display participants fullname depending on the receiver/viewed capability 
If the logged in user has 'viewfullnames' capabilities then they will see the user fullname as $CFG->alternativefullnameformat otherwise as $CFG->fullnamedisplay

- Include students course name in the email notifications sent

Regards,

Sumaiya