### PR TITLE
Load teacher names in dialogue creation with large number of users and groups in a course

### DIFF
--- a/classes/external/search_users.php
+++ b/classes/external/search_users.php
@@ -37,7 +37,6 @@ use external_multiple_structure;
 use core_user_external;
 use context_module;
 use moodle_exception;
-use course_enrolment_manager;
 use core\session\exception;
 
 /**
@@ -120,7 +119,7 @@ class search_users extends external_api {
                                                         $groups);
 
         } else {
-            $manager = new course_enrolment_manager($PAGE, $course);
+            $manager = new \mod_dialogue\local\course_enrolment_manager($PAGE, $course);
             $users = $manager->search_users($params['search'],
                                             $params['searchanywhere'],
                                             $params['page'],
@@ -137,10 +136,6 @@ class search_users extends external_api {
         foreach ($users['users'] as $user) {
             // Don't include logged in user as a possible user.
             if ($user->id == $USER->id) {
-                continue;
-            }
-            if (!has_capability('mod/dialogue:receive', $context, $user)) {
-                // User does not have the ability to receive so remove them.
                 continue;
             }
             if ($userdetails = user_get_user_details($user, $course, $requiredfields)) {

--- a/classes/local/course_enrolment_manager.php
+++ b/classes/local/course_enrolment_manager.php
@@ -60,4 +60,59 @@ class course_enrolment_manager extends \course_enrolment_manager {
         $params = array_merge($params, $inparams);
         return $this->execute_search_queries($search, $fields, $countfields, $sql, $params, $page, $perpage, 0, false);
     }
+
+    /**
+     * Searches through the enrolled users in this course based on search_users but with mod_dialogue permission.
+     *
+     * @param string $search The search term.
+     * @param bool $searchanywhere Can the search term be anywhere, or must it be at the start.
+     * @param int $page Starting at 0.
+     * @param int $perpage Number of users returned per page.
+     * @param bool $returnexactcount Return the exact total users using count_record or not.
+     * @param ?int $contextid Context ID we are in - we might use search on activity level and its group mode can be different from course group mode.
+     * @return array with two or three elements:
+     *      int totalusers Number users matching the search. (This element only exist if $returnexactcount was set to true)
+     *      array users List of user objects returned by the query.
+     *      boolean moreusers True if there are still more users, otherwise is False.
+     */
+    public function search_users(string $search = '', bool $searchanywhere = false, int $page = 0, int $perpage = 25,
+            bool $returnexactcount = false, ?int $contextid = null) {
+        global $USER;
+
+        [$ufields, $joins, $params, $wherecondition] = $this->get_basic_search_conditions($search, $searchanywhere);
+
+        if (isset($contextid)) {
+            // If contextid is set, we need to determine the group mode that should be used (module or course).
+            [$context, $course, $cm] = get_context_info_array($contextid);
+            // If cm instance is returned, then use the group mode from the module, otherwise get the course group mode.
+            $groupmode = $cm ? groups_get_activity_groupmode($cm, $course) : groups_get_course_groupmode($this->course);
+        } else {
+            // Otherwise, default to the group mode of the course.
+            $context = $this->context;
+            $groupmode = groups_get_course_groupmode($this->course);
+        }
+
+        if ($groupmode == SEPARATEGROUPS && !has_capability('moodle/site:accessallgroups', $context)) {
+            $groups = groups_get_all_groups($this->course->id, $USER->id, 0, 'g.id');
+            $groupids = array_column($groups, 'id');
+            if (!$groupids) {
+                return ['totalusers' => 0, 'users' => [], 'moreusers' => false];
+            }
+        } else {
+            $groupids = [];
+        }
+
+        [$enrolledsql, $enrolledparams] = get_enrolled_sql($context, 'mod/dialogue:receive', $groupids);
+
+        $fields      = 'SELECT ' . $ufields;
+        $countfields = 'SELECT COUNT(u.id)';
+        $sql = " FROM {user} u
+                      $joins
+                 JOIN ($enrolledsql) je ON je.id = u.id
+                WHERE $wherecondition";
+
+        $params = array_merge($params, $enrolledparams);
+
+        return $this->execute_search_queries($search, $fields, $countfields, $sql, $params, $page, $perpage, 0, $returnexactcount);
+    }
 }


### PR DESCRIPTION
Hi,

Improve the performance of the user selector on the create dialogue page when used in courses with large numbers of users in groups – This will resolve the issue experienced where Teacher names are not loading within the selector in large groups.

To replicate the issue have the below setup:

- Create a  Moodle 4.1 instance has a large number of users and groups
- Create 25,000 users,
- Create 5 courses,
- Add the Dialogue activity to at least one course,
- Create 5 groups in each of the 5 courses,
- Enrol 5000 users with the Student role on to each of the 5 courses,
- Assign 1000 users to each group,
- Enrol 5 additional users with the Teacher role on to each of the 5 courses,
- Assign 1 Teacher to each of the 5 groups
- Remove mod/dialogue:receive capability from the 'student' role

Log in as a Student who is enrolled on the same course which has the Dialogue Activity added,

- Access the course and go to the Dialogue activity,
- Click on the 'Create' link,
- Locate the 'Open with' search field and click the search arrow.

Expected behaviour: The search should return the name of the Teacher who is in the same group as the logged on Student.
Actual behaviour: No results are returned.

Regards,
Sumaiya