### PR TITLE
Fix error on draft or new messages

### DIFF
--- a/classes/local/course_enrolment_manager.php
+++ b/classes/local/course_enrolment_manager.php
@@ -70,10 +70,7 @@ class course_enrolment_manager extends \course_enrolment_manager {
      * @param int $perpage Number of users returned per page.
      * @param bool $returnexactcount Return the exact total users using count_record or not.
      * @param ?int $contextid Context ID we are in - we might use search on activity level and its group mode can be different from course group mode.
-     * @return array with two or three elements:
-     *      int totalusers Number users matching the search. (This element only exist if $returnexactcount was set to true)
-     *      array users List of user objects returned by the query.
-     *      boolean moreusers True if there are still more users, otherwise is False.
+     * @return array An array of users
      */
     public function search_users(string $search = '', bool $searchanywhere = false, int $page = 0, int $perpage = 25,
             bool $returnexactcount = false, ?int $contextid = null) {

--- a/formlib.php
+++ b/formlib.php
@@ -46,6 +46,7 @@ class mod_dialogue_message_form extends moodleform {
 
         $mform->addElement('editor', 'body', get_string('message', 'dialogue'), null, self::editor_options());
         $mform->setType('body', PARAM_RAW);
+        $mform->addRule('body', null, 'required', null, 'client');
 
         // Maxattachments = 0 = No attachments at all.
         if (!get_config('dialogue', 'maxattachments') || !empty($PAGE->activityrecord->maxattachments)) {
@@ -254,14 +255,14 @@ class mod_dialogue_conversation_form extends mod_dialogue_message_form {
             'ajax' => 'mod_dialogue/form-user-selector',
             'multiple' => true,
             'cmid' => $cm->id,
-            'valuehtmlcallback' => function($value, $USER, $cm) {
+            'valuehtmlcallback' => function($value) {
                 global $OUTPUT;
                 $userfieldsapi = \core_user\fields::for_name();
                 $allusernames = $userfieldsapi->get_sql('', false, '', '', false)->selects;
                 $fields = 'id, ' . $allusernames;
                 $user = \core_user::get_user($value, $fields);
                 $useroptiondata = [
-                    'fullname' => dialogue_add_user_fullname($user, $USER, $cm),
+                    'fullname' => dialogue_add_user_fullname($user),
                 ];
                 return $OUTPUT->render_from_template('mod_dialogue/form-user-selector-suggestion', $useroptiondata);
             }

--- a/locallib.php
+++ b/locallib.php
@@ -488,8 +488,8 @@ function dialogue_contains_draft_files($draftid) {
 }
 
 /**
- * Get the name for a user - hiding their full name if the required capability
- * is missing.
+ * Get the name for a user -
+ * hiding their full name if the required capability is missing.
  *
  * @param stdClass $userviewed the user whose details are being viewed
  * @param stdClass $userviewedby the user who is viewing these details
@@ -497,7 +497,15 @@ function dialogue_contains_draft_files($draftid) {
  *
  * @return string fullname
  */
-function dialogue_add_user_fullname(stdClass $userviewed, stdClass $userviewedby, stdClass $cm) {
+function dialogue_add_user_fullname(stdClass $userviewed,
+    stdClass $userviewedby = null, stdClass $cm = null) {
+    global $PAGE, $USER;
+    if (!$userviewedby) {
+        $userviewedby = $USER;
+    }
+    if (!$cm) {
+        $cm = $PAGE->cm;
+    }
     $capability = 'moodle/site:viewfullnames';
     $context = context_module::instance($cm->id);
     $hasviewfullnames = has_capability($capability, $context, $userviewedby);


### PR DESCRIPTION
Hi
This fixes the below error which is thrown in two scenarios:
1. If the message field is left blank for new messages;
2. When viewing a draft message. 

The error is: 
"Exception - Too few arguments to function mod_dialogue_conversation_form::{closure}(), 1 passed in [dirroot]/lib/form/autocomplete.php on line 245 and exactly 3 expected"

Regards,
Sumaiya