### PR TITLE
Search users group add capability check

### DIFF
--- a/classes/local/course_enrolment_manager.php
+++ b/classes/local/course_enrolment_manager.php
@@ -46,18 +46,22 @@ class course_enrolment_manager extends \course_enrolment_manager {
         $fields      = 'SELECT ' . $ufields;
         $countfields = 'SELECT COUNT(u.id)';
         list($insql, $inparams) = $DB->get_in_or_equal(array_keys($groups), SQL_PARAMS_NAMED);
-
+        $capability = 'mod/dialogue:receive';
+        $context = $this->context;
+        [$enrolledsql, $enrolledparams] = get_enrolled_sql($context, $capability, 0, true);
         $sql = " FROM {user} u
                       $joins
                  JOIN {user_enrolments} ue ON ue.userid = u.id
                  JOIN {enrol} e ON ue.enrolid = e.id
                  JOIN ({groups_members} gm JOIN {groups} g ON (g.id = gm.groupid))
                       ON (u.id = gm.userid AND g.courseid = e.courseid)
+                JOIN ($enrolledsql) je ON je.id = u.id
                 WHERE $wherecondition
+                  AND u.suspended = 0
                   AND e.courseid = :courseid
                   AND g.id $insql";
         $params['courseid'] = $this->course->id;
-        $params = array_merge($params, $inparams);
+        $params = array_merge($params, $inparams, $enrolledparams);
         return $this->execute_search_queries($search, $fields, $countfields, $sql, $params, $page, $perpage, 0, false);
     }
 
@@ -106,7 +110,8 @@ class course_enrolment_manager extends \course_enrolment_manager {
         $sql = " FROM {user} u
                       $joins
                  JOIN ($enrolledsql) je ON je.id = u.id
-                WHERE $wherecondition";
+                WHERE $wherecondition
+                AND u.suspended = 0";
 
         $params = array_merge($params, $enrolledparams);
 


### PR DESCRIPTION
Hi,

This will add capability check and remove suspended users from the ajax user search. 
 
Whenever the field "Use course groups" within each Dialogue instance is ticked and the user's role doesn't have the 'accessallgroups' capability, then the 'search_users_with_groups' php function returns all users in the course who are in the same groups as the user. e.g. If the user clicking on the ajax Search field is in the course groups: ABC, G123, Course100, then the code returns all users who is also in all those groups: Students, teachers, admins, even users who's enrolments are suspended on the course. It is because the function is not checking whether the returned users have active enrolments and also the 'mod/dialogue:receive' capability.

Regards,
Sumaiya
