### PR TITLE
Add control over student role if it doesn't exist fix #146

### DIFF
--- a/viewconversationsbyrole.php
+++ b/viewconversationsbyrole.php
@@ -42,9 +42,20 @@ $context = context_module::instance($cm->id);
 
 require_login($course, false, $cm);
 
-$rolenames = role_fix_names(get_profile_roles($context), $context, ROLENAME_ALIAS, true);
+$profileroles = get_profile_roles($context);
+$shortnameroles = [];
+foreach ($profileroles as $roles) {
+    $shortnameroles[] = $roles->shortname;
+}
+
+$rolenames = role_fix_names($profileroles, $context, ROLENAME_ALIAS, true);
 if (!$roleid) {
-    $roleid  = $DB->get_field('role', 'id', array('shortname' => 'student'), MUST_EXIST);
+    if (array_search('student', $shortnameroles, true)) {
+        $roleid = $DB->get_field('role', 'id', ['shortname' => 'student'], MUST_EXIST);
+    } else {
+        $currentroleobject = current($profileroles);
+        $roleid = $DB->get_field('role', 'id', ['shortname' => $currentroleobject->shortname], MUST_EXIST);
+    }
 }
 
 // Now set params on pageurl will later be set on $PAGE.


### PR DESCRIPTION
This should fix #146 
We check if the student role exits, if not, we will get the first role associated.

Please see this other PR for another way of fixing this => https://github.com/danmarsden/moodle-mod_dialogue/pull/148

