### PR TITLE
Remove extra db request, add control over roleid / student fix #146

### DIFF
--- a/viewconversationsbyrole.php
+++ b/viewconversationsbyrole.php
@@ -42,10 +42,17 @@ $context = context_module::instance($cm->id);
 
 require_login($course, false, $cm);
 
-$rolenames = role_fix_names(get_profile_roles($context), $context, ROLENAME_ALIAS, true);
+$profileroles = get_profile_roles($context);
+$shortnameroles = [];
 if (!$roleid) {
-    $roleid  = $DB->get_field('role', 'id', array('shortname' => 'student'), MUST_EXIST);
+    foreach ($profileroles as $roles) {
+        $roleid = $roles->id;
+        if ($roles->shortname == 'student') {
+            break;
+        }
+    }
 }
+$rolenames = role_fix_names($profileroles, $context, ROLENAME_ALIAS, true);
 
 // Now set params on pageurl will later be set on $PAGE.
 $pageurl = new moodle_url('/mod/dialogue/viewconversationsbyrole.php');


### PR DESCRIPTION
fix #146 
I have chosen to remove the DB call here as we already have all the role id as part of the get_profile_roles() method
We get the corresponding roleid for 'student', and if this role doesn't exist, we get the last roleid of the array.

Please compare to this PR for the best option => https://github.com/danmarsden/moodle-mod_dialogue/pull/147 