### PR TITLE
Fix dropdown  button issue / Keep role ID in url for view conversation by role

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -455,7 +455,6 @@ body.path-mod-dialogue #region-main .dropdown-menu {
     top: 100%;
     left: 0;
     z-index: 1000;
-    display: none;
     float: left;
     min-width: 160px;
     padding: 5px 0;

--- a/viewconversationsbyrole.php
+++ b/viewconversationsbyrole.php
@@ -62,6 +62,7 @@ if ($page) {
 }
 $pageurl->param('sort', $sort);
 $pageurl->param('direction', $direction);
+$pageurl->param('roleid', $roleid);
 // Set up a return url that will be stored to session.
 $returnurl = clone($pageurl);
 $returnurl->remove_params('page');


### PR DESCRIPTION
fix #149 

When you use the "sorted by" 
<img width="186" height="136" alt="image" src="https://github.com/user-attachments/assets/88fe9ff6-f54c-462a-a977-3238b5c5a07e" />
The role id in the URL is removed, so the filter jump back to the default role. This PR fix that as well