### PR TITLE
Fix Cancel button to bypass validation of required fields

### DIFF
--- a/formlib.php
+++ b/formlib.php
@@ -80,8 +80,7 @@ class mod_dialogue_message_form extends moodleform {
             get_string('send', 'dialogue'), array('class' => 'send-button'));
         $actionbuttongroup[] =& $mform->createElement('submit', 'save',
             get_string('savedraft', 'dialogue'), array('class' => 'savedraft-button'));
-        $actionbuttongroup[] =& $mform->createElement('submit', 'cancel',
-            get_string('cancel'), array('class' => 'cancel-button'));
+        $actionbuttongroup[] =& $mform->createElement('cancel');
 
         $actionbuttongroup[] =& $mform->createElement('submit', 'trash',
             get_string('trashdraft', 'dialogue'), array('class' => 'trashdraft-button pull-right'));


### PR DESCRIPTION
This change uses Moodle's built-in cancel button behavior, which already bypasses form validation.

Previously, clicking Cancel attempted to submit the form and triggered validation errors for missing required fields, preventing users from canceling as expected.

Tested on Moodle 4.5.11.

Closes #152
