### PR TITLE
Display group selector to filter conversations by group

### DIFF
--- a/classes/conversations_by_author.php
+++ b/classes/conversations_by_author.php
@@ -49,6 +49,10 @@ class conversations_by_author extends conversations {
      * @var array
      */
     protected $states = array();
+    /**
+     * @var int
+     */
+    protected $groupid = 0;
 
     /**
      * Setup
@@ -90,6 +94,17 @@ class conversations_by_author extends conversations {
 
             $this->params['userid'] = $USER->id;
             $this->params['dialogueid'] = $this->dialogue->activityrecord->id;
+        }
+
+        if ($this->groupid) {
+            $this->basesql .= " JOIN (SELECT DISTINCT dp.conversationid
+                                        FROM {dialogue_participants} dp
+                                        JOIN {groups_members} gm ON gm.userid = dp.userid
+                                       WHERE dp.dialogueid = :groupdialogueid
+                                         AND gm.groupid = :groupid) groupfilter ON groupfilter.conversationid = dc.id";
+
+            $this->params['groupdialogueid'] = $this->dialogue->activityrecord->id;
+            $this->params['groupid'] = $this->groupid;
         }
 
         $this->fields = array('userid' => 'u.id AS userid',
@@ -264,6 +279,10 @@ class conversations_by_author extends conversations {
                 throw new \moodle_exception("Cannot sort on $name");
         }
         return $this->orderbysql = $orderby;
+    }
+
+    public function set_group($groupid) {
+        $this->groupid = $groupid;
     }
 
 }

--- a/classes/external/search_users.php
+++ b/classes/external/search_users.php
@@ -102,8 +102,7 @@ class search_users extends external_api {
 
         require_capability('mod/dialogue:open', $context);
 
-        if (!has_capability('moodle/site:accessallgroups', $context) &&
-            $DB->record_exists('dialogue', ['id' => $cm->instance, 'usecoursegroups' => 1])) {
+        if (!has_capability('moodle/site:accessallgroups', $context) && $cm->groupmode == SEPARATEGROUPS) {
 
             // When a student is in multiple groups, the core filters don't support this easily so we have to check each user
             // This is in-efficient but hopefully not too nasty.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -30,7 +30,7 @@
  * @return bool
  */
 function xmldb_dialogue_upgrade($oldversion) {
-    global $DB;
+    global $CFG, $DB;
 
     $dbman = $DB->get_manager();
 
@@ -46,6 +46,30 @@ function xmldb_dialogue_upgrade($oldversion) {
 
         // savepoint reached.
         upgrade_mod_savepoint(true, 2024120900, 'dialogue');
+    }
+
+    if ($oldversion >= 2013101501 && $oldversion < 2026051500) {
+        // Migrate the old property usecoursegroups to $cm->groupmode = SEPARATEGROUPS or NOGROUPS.
+        require_once($CFG->dirroot . '/course/lib.php');
+
+        $moduleid = $DB->get_field('modules', 'id', ['name' => 'dialogue']);
+
+        if ($moduleid) {
+            $sql = "SELECT cm.id, d.usecoursegroups
+                      FROM {course_modules} cm
+                      JOIN {dialogue} d ON d.id = cm.instance
+                     WHERE cm.module = :moduleid";
+            $recordset = $DB->get_recordset_sql($sql, ['moduleid' => $moduleid]);
+
+            foreach ($recordset as $record) {
+                $groupmode = $record->usecoursegroups ? SEPARATEGROUPS : NOGROUPS;
+                set_coursemodule_groupmode($record->id, $groupmode);
+            }
+
+            $recordset->close();
+        }
+
+        upgrade_mod_savepoint(true, 2026051500, 'dialogue');
     }
 
     return true;

--- a/lang/en/dialogue.php
+++ b/lang/en/dialogue.php
@@ -206,10 +206,6 @@ $string['unread'] = 'Unread';
 $string['unreadmessages'] = 'Unread messages';
 $string['unreadmessagesnumber'] = '{$a} unread messages';
 $string['unreadmessagesone'] = '1 unread message';
-$string['usecoursegroups'] = 'Use course groups';
-$string['usecoursegroups_help'] = 'If the course has defined groups a further restriction will be added to who a dialogue can
-be opened with. Dialogues can only be opened between group members unless the person opening the dialogue has the "Access all groups"
-capability set.';
 $string['usesearch'] = 'Use search to find people to start a dialogue with';
 $string['viewconversations'] = 'View conversations';
 $string['viewconversationsbyrole'] = 'View conversations by role';

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@
 function dialogue_supports($feature) {
     switch($feature) {
         case FEATURE_GROUPS:
-            return false;
+            return true;
         case FEATURE_GROUPINGS:
             return false;
         case FEATURE_MOD_INTRO:

--- a/mod_form.php
+++ b/mod_form.php
@@ -63,10 +63,6 @@ class mod_dialogue_mod_form extends moodleform_mod {
         $mform->addHelpButton('maxattachments', 'maxattachments', 'dialogue');
         $mform->setDefault('maxattachments', $pluginconfig->maxattachments);
 
-        $mform->addElement('checkbox', 'usecoursegroups', get_string('usecoursegroups', 'dialogue'));
-        $mform->addHelpButton('usecoursegroups', 'usecoursegroups', 'dialogue');
-        $mform->setDefault('usecoursegroups', 0);
-
         $this->standard_grading_coursemodule_elements();
 
         $this->standard_coursemodule_elements();
@@ -82,9 +78,6 @@ class mod_dialogue_mod_form extends moodleform_mod {
         $data = parent::get_data();
         if (!$data) {
             return false;
-        }
-        if (!isset($data->usecoursegroups)) {
-            $data->usecoursegroups = 0;
         }
         return $data;
     }

--- a/tests/behat/no_groups.feature
+++ b/tests/behat/no_groups.feature
@@ -1,0 +1,42 @@
+@mod @mod_dialogue @javascript
+Feature: Students can start conversations with teachers from any group when groups are disabled
+	As a student
+	I need to see all available teachers in the open with selector
+	So that I can start a conversation even when users belong to different groups
+
+	Background:
+		Given the following "users" exist:
+			| username | firstname | lastname | email                |
+			| teacher1 | Teacher   | 1        | teacher1@example.com |
+			| teacher2 | Teacher   | 2        | teacher2@example.com |
+			| student1 | Student   | 1        | student1@example.com |
+			| student2 | Student   | 2        | student2@example.com |
+		And the following "courses" exist:
+			| fullname | shortname |
+			| Course 1 | C1        |
+		And the following "course enrolments" exist:
+			| user     | course | role           |
+			| teacher1 | C1     | editingteacher |
+			| teacher2 | C1     | editingteacher |
+			| student1 | C1     | student        |
+			| student2 | C1     | student        |
+		And the following "groups" exist:
+			| name    | course | idnumber |
+			| Class 1 | C1     | class1   |
+			| Class 2 | C1     | class2   |
+		And the following "group members" exist:
+			| user     | group  |
+			| teacher1 | class1 |
+			| student1 | class1 |
+			| teacher2 | class2 |
+			| student2 | class2 |
+		And the following "activities" exist:
+			| activity | name          | course | idnumber  |
+			| dialogue | Test Dialogue | C1     | dialogue1 |
+
+	Scenario: Student can see teachers from all groups in the open with selector
+		Given I am on the "Test Dialogue" "dialogue activity" page logged in as student1
+		When I click on "Create" "link"
+		And I open the autocomplete suggestions list
+		Then I should see "Teacher 1"
+		And I should see "Teacher 2"

--- a/tests/behat/separate_groups.feature
+++ b/tests/behat/separate_groups.feature
@@ -1,0 +1,42 @@
+@mod @mod_dialogue @javascript
+Feature: Students can start conversations only with teachers from their own group when separate groups are enabled
+	As a student
+	I need to see only teachers from my own group in the open with selector
+	So that group separation is respected when starting a conversation
+
+	Background:
+		Given the following "users" exist:
+			| username | firstname | lastname | email                |
+			| teacher1 | Teacher   | 1        | teacher1@example.com |
+			| teacher2 | Teacher   | 2        | teacher2@example.com |
+			| student1 | Student   | 1        | student1@example.com |
+			| student2 | Student   | 2        | student2@example.com |
+		And the following "courses" exist:
+			| fullname | shortname |
+			| Course 1 | C1        |
+		And the following "course enrolments" exist:
+			| user     | course | role           |
+			| teacher1 | C1     | editingteacher |
+			| teacher2 | C1     | editingteacher |
+			| student1 | C1     | student        |
+			| student2 | C1     | student        |
+		And the following "groups" exist:
+			| name    | course | idnumber |
+			| Class 1 | C1     | class1   |
+			| Class 2 | C1     | class2   |
+		And the following "group members" exist:
+			| user     | group  |
+			| teacher1 | class1 |
+			| student1 | class1 |
+			| teacher2 | class2 |
+			| student2 | class2 |
+		And the following "activities" exist:
+			| activity | name          | course | idnumber  | groupmode |
+			| dialogue | Test Dialogue | C1     | dialogue1 | 1         |
+
+	Scenario: Student can see only teachers from their own group in the open with selector
+		Given I am on the "Test Dialogue" "dialogue activity" page logged in as student1
+		When I click on "Create" "link"
+		And I open the autocomplete suggestions list
+		Then I should see "Teacher 1"
+		And I should not see "Teacher 2"

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025032000;
-$plugin->release   = 2025032000;
+$plugin->version   = 2026051500;
+$plugin->release   = 2026051500;
 $plugin->requires  = 2024100700;  // Requires 4.5 or higher.
 $plugin->component = 'mod_dialogue';    // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;    // This version's maturity level.

--- a/view.php
+++ b/view.php
@@ -72,6 +72,11 @@ $list = new \mod_dialogue\conversations_by_author($dialogue, $page, \mod_dialogu
 $list->set_state($state);
 $list->set_order($sort, $direction);
 
+if ($activityrecord->usecoursegroups) {
+    $cm->groupmode = SEPARATEGROUPS; // For groups_print_activity_menu() to work correctly.
+    $list->set_group(optional_param('group', 0, PARAM_INT));
+}
+
 $renderer = $PAGE->get_renderer('mod_dialogue');
 
 echo $OUTPUT->header();
@@ -81,6 +86,9 @@ echo $OUTPUT->heading(format_string($activityrecord->name));
 echo $renderer->tab_navigation($dialogue);
 echo $renderer->state_button_group();
 echo $renderer->list_sortby(\mod_dialogue\conversations_by_author::get_sort_options(), $sort, $direction);
+if ($activityrecord->usecoursegroups) {
+    echo groups_print_activity_menu($cm, $pageurl);
+}
 echo $renderer->conversation_listing($list);
 echo $OUTPUT->footer($course);
 

--- a/view.php
+++ b/view.php
@@ -72,8 +72,7 @@ $list = new \mod_dialogue\conversations_by_author($dialogue, $page, \mod_dialogu
 $list->set_state($state);
 $list->set_order($sort, $direction);
 
-if ($activityrecord->usecoursegroups) {
-    $cm->groupmode = SEPARATEGROUPS; // For groups_print_activity_menu() to work correctly.
+if ($cm->groupmode == SEPARATEGROUPS) {
     $list->set_group(optional_param('group', 0, PARAM_INT));
 }
 
@@ -86,7 +85,7 @@ echo $OUTPUT->heading(format_string($activityrecord->name));
 echo $renderer->tab_navigation($dialogue);
 echo $renderer->state_button_group();
 echo $renderer->list_sortby(\mod_dialogue\conversations_by_author::get_sort_options(), $sort, $direction);
-if ($activityrecord->usecoursegroups) {
+if ($cm->groupmode == SEPARATEGROUPS) {
     echo groups_print_activity_menu($cm, $pageurl);
 }
 echo $renderer->conversation_listing($list);


### PR DESCRIPTION
In some use cases, users may have conversations with people from different groups, so being able to filter conversations by group is useful.

Although the Dialogue plugin does not use the native group setting and relies on its own `usecoursegroups` attribute, this pull request implements the same group selector used in other activities.

If this implementation is not suitable and another approach is preferred, I am happy to try something different in an alternative PR.

<img width="840" height="510" alt="image" src="https://github.com/user-attachments/assets/afd992cf-039d-4916-a6ad-5ff3215ebe44" />
